### PR TITLE
/roddy/.roddy/jfxlibInfo is missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -166,5 +166,8 @@ VOLUME /var /etc /root /usr /reference /data /roddy /mnt
 # nested volumes, not sure why we need these but otherwise they end up read-only
 VOLUME /var/run/gridengine
 
+RUN mkdir /roddy/.roddy
+COPY jfxlibInfo /roddy/.roddy/
+
 
 CMD ["/bin/bash", "/start.sh"]

--- a/Dockstore.cwl
+++ b/Dockstore.cwl
@@ -14,7 +14,7 @@ dct:contributor:
 
 requirements:
 - class: DockerRequirement
-  dockerPull: quay.io/pancancer/pcawg-dkfz-workflow:2.0.5_cwl1.0
+  dockerPull: quay.io/pancancer/pcawg-dkfz-workflow:2.0.6_cwl1.0
 
 cwlVersion: v1.0
 

--- a/Dockstore.cwl
+++ b/Dockstore.cwl
@@ -14,7 +14,7 @@ dct:contributor:
 
 requirements:
 - class: DockerRequirement
-  dockerPull: quay.io/pancancer/pcawg-dkfz-workflow:2.0.1_cwl1.0
+  dockerPull: quay.io/pancancer/pcawg-dkfz-workflow:2.0.5_cwl1.0
 
 cwlVersion: v1.0
 

--- a/jfxlibInfo
+++ b/jfxlibInfo
@@ -1,0 +1,1 @@
+/roddy/bin/Roddy/dist/runtimeDevel/jre/lib/ext/jfxrt.jar


### PR DESCRIPTION
To fix the error at Line65 in runwrapper.sh
` bash roddy.sh rerun dkfzPancancerBase@copyNumberEstimation run_id --waitforjobs --useconfig=applicationPropertiesAllLocal.ini `

> /roddy/bin/Roddy/dist/bin/2.2.49/roddy.sh:
 line 36: /roddy/.roddy/jfxlibInfo: No such file or directory
cat: /roddy/.roddy/jfxlibInfo: No such file or directory