### PR TITLE
 Fix the link /roddy/bin/Roddy/dist/runtimeDevel/jre

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,10 @@ ADD scripts/combineJsons.py /roddy/bin/combineJsons.py
 
 ADD scripts/python_modules /roddy/bin/python_modules
 
-RUN cd /roddy/bin/Roddy/dist/runtimeDevel && ln -sf groovy* groovy && ln -sf jdk* jdk && ln -sf jdk/jre jre; \
+RUN cd /roddy/bin/Roddy/dist/runtimeDevel;
+    ln -sf groovy2.3.6 groovy; \
+    ln -sf jdk1.8.0_20 jdk; \
+    ln -sf jdk1.8.0_20/jre jre; \
     cd /roddy/bin/Roddy && cp applicationPropertiesAllLocal.ini applicationProperties.ini; \
     bash /roddy/sgeResetup.sh; \
     qconf -Mc /roddy/bin/sgeConfig.txt; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ ADD scripts/combineJsons.py /roddy/bin/combineJsons.py
 
 ADD scripts/python_modules /roddy/bin/python_modules
 
-RUN cd /roddy/bin/Roddy/dist/runtimeDevel;
+RUN cd /roddy/bin/Roddy/dist/runtimeDevel; \
     ln -sf groovy2.3.6 groovy; \
     ln -sf jdk1.8.0_20 jdk; \
     ln -sf jdk1.8.0_20/jre jre; \

--- a/Dockstore.cwl
+++ b/Dockstore.cwl
@@ -14,7 +14,7 @@ dct:contributor:
 
 requirements:
 - class: DockerRequirement
-  dockerPull: quay.io/pancancer/pcawg-dkfz-workflow:2.0.6_cwl1.0
+  dockerPull: quay.io/pancancer/pcawg-dkfz-workflow:2.0.7_cwl1.0
 
 cwlVersion: v1.0
 


### PR DESCRIPTION
To fix the error of 
`java.lang.RuntimeException: Process could not be run
        Command: sh -c [[ -f "/roddy/.roddy/compressedAnalysisTools/cTools_CopyNumberEstimationWorkflow:1.0.189_copyNumberEstimationWorkflow.zip" ]] && rm ...
        return code is: 15`