### PR TITLE
Remove hardcoded /var/spool/cwl, increase memory setting in configuration XMLs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,15 @@ RUN wget --quiet -O Roddy_2.2.49_COW_1.0.132-1_CNE_1.0.189.tar.gz https://dcc.ic
 
 COPY patches/analysisCopyNumberEstimation.xml /roddy/bin/Roddy/dist/plugins/CopyNumberEstimationWorkflow_1.0.189/resources/configurationFiles/analysisCopyNumberEstimation.xml
 
+RUN cd /roddy/bin/Roddy/dist/plugins/CopyNumberEstimationWorkflow_1.0.189/resources/configurationFiles
+    && for f in *.xml; do cat $f |perl -nae 'if(/ memory="(.+?)"/) {$mem=$1; s/ memory=".+?"/ memory="6"/ if $mem < 6}; print' > tmp.xml && mv tmp.xml $f; done
+
+RUN cd /roddy/bin/Roddy/dist/plugins/COWorkflows_1.0.132-1/resources/configurationFiles
+    && for f in *.xml; do cat $f |perl -nae 'if(/ memory="(.+?)"/) {$mem=$1; s/ memory=".+?"/ memory="6"/ if $mem < 6}; print' > tmp.xml && mv tmp.xml $f; done
+
+RUN cd /roddy/bin/Roddy/dist/plugins/DefaultPlugin/resources/configurationFiles
+    && for f in *.xml; do cat $f |perl -nae 'if(/ memory="(.+?)"/) {$mem=$1; s/ memory=".+?"/ memory="6"/ if $mem < 6}; print' > tmp.xml && mv tmp.xml $f; done
+
 
 #Grid engine setup - This is taken from the pancancer setup for SGE clusters.
 RUN export DEBIAN_FRONTEND=noninteractive \

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,8 +102,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && qconf -as $HOST \
     && cd /roddy \
     && chmod 777 sgeInit.sh \
-	&& bash sgeInit.sh \
-	&& rm sgeInit.sh
+    && bash sgeInit.sh \
+    && rm sgeInit.sh
 
 RUN cd /roddy/bin/Roddy/dist/runtimeDevel \
     && ln -sf groovy* groovy \

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,13 +79,13 @@ RUN wget --quiet -O Roddy_2.2.49_COW_1.0.132-1_CNE_1.0.189.tar.gz https://dcc.ic
 
 COPY patches/analysisCopyNumberEstimation.xml /roddy/bin/Roddy/dist/plugins/CopyNumberEstimationWorkflow_1.0.189/resources/configurationFiles/analysisCopyNumberEstimation.xml
 
-RUN cd /roddy/bin/Roddy/dist/plugins/CopyNumberEstimationWorkflow_1.0.189/resources/configurationFiles
+RUN cd /roddy/bin/Roddy/dist/plugins/CopyNumberEstimationWorkflow_1.0.189/resources/configurationFiles \
     && for f in *.xml; do cat $f |perl -nae 'if(/ memory="(.+?)"/) {$mem=$1; s/ memory=".+?"/ memory="6"/ if $mem < 6}; print' > tmp.xml && mv tmp.xml $f; done
 
-RUN cd /roddy/bin/Roddy/dist/plugins/COWorkflows_1.0.132-1/resources/configurationFiles
+RUN cd /roddy/bin/Roddy/dist/plugins/COWorkflows_1.0.132-1/resources/configurationFiles \
     && for f in *.xml; do cat $f |perl -nae 'if(/ memory="(.+?)"/) {$mem=$1; s/ memory=".+?"/ memory="6"/ if $mem < 6}; print' > tmp.xml && mv tmp.xml $f; done
 
-RUN cd /roddy/bin/Roddy/dist/plugins/DefaultPlugin/resources/configurationFiles
+RUN cd /roddy/bin/Roddy/dist/plugins/DefaultPlugin/resources/configurationFiles \
     && for f in *.xml; do cat $f |perl -nae 'if(/ memory="(.+?)"/) {$mem=$1; s/ memory=".+?"/ memory="6"/ if $mem < 6}; print' > tmp.xml && mv tmp.xml $f; done
 
 

--- a/Dockstore.cwl
+++ b/Dockstore.cwl
@@ -14,7 +14,7 @@ dct:contributor:
 
 requirements:
 - class: DockerRequirement
-  dockerPull: quay.io/pancancer/pcawg-dkfz-workflow:2.0.8_cwl1.0
+  dockerPull: quay.io/pancancer/pcawg-dkfz-workflow:increase_memory_setting
 
 cwlVersion: v1.0
 

--- a/runwrapper.sh
+++ b/runwrapper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-sudo bash ~/sgeResetup.sh
+gosu roddy /bin/bash /roddy/sgeResetup.sh
 
 CONFIG_FILE=/mnt/datastore/workflow_data/workflow.ini
 
@@ -40,7 +40,7 @@ for (( i=0; i<${#tumorBams[@]}; i++ )); do
 
 	# Call Roddy
 
-	cd ~/bin/Roddy
+	cd /roddy/bin/Roddy
 
 	export aceseqlog=/roddy/logs/aceseq_$pid.log
 	export aceseqrc=/roddy/logs/aceseq_$pid.rc

--- a/scripts/run_workflow.pl
+++ b/scripts/run_workflow.pl
@@ -17,12 +17,12 @@ my ($run_id, $normal_bam, $tumor_bam, $bedpe, $reference, $output_dir);
 my $wfversion = "2.0.0";
 
 GetOptions (
+  "output-dir=s" => \$output_dir,
   "run-id=s"   => \$run_id,
   "normal-bam=s" => \$normal_bam,
   "tumor-bam=s" => \$tumor_bam,
   "delly-bedpe=s" => \$bedpe,
   "reference-gz=s" => \$reference,
-  "output-dir=s" => \$output_dir
 )
 # TODO: need to add all the new params, then symlink the ref files to the right place
  or die("Error in command line arguments\n");
@@ -34,7 +34,7 @@ system("sudo chmod a+rwx /tmp");
 my $pwd = `pwd`;
 print "Present working directory is: $pwd\n";
 
-$ENV{'HOME'} = $output_dir
+$ENV{'HOME'} = $output_dir;
 
 #check assumptions
 run("whoami");

--- a/scripts/run_workflow.pl
+++ b/scripts/run_workflow.pl
@@ -34,8 +34,6 @@ system("sudo chmod a+rwx /tmp");
 my $pwd = `pwd`;
 print "Present working directory is: $pwd\n";
 
-$ENV{'HOME'} = $output_dir;
-
 #check assumptions
 run("whoami");
 run("env");
@@ -78,7 +76,7 @@ print OUT $config;
 close OUT;
 
 # NOW RUN WORKFLOW
-my $error = system("/bin/bash -c '/roddy/bin/runwrapper.sh'");
+my $error = system("gosu roddy /bin/bash -c '/roddy/bin/runwrapper.sh'");
 
 # MOVE THESE TO THE RIGHT PLACE FOR PROVISION OUT
 system("mv /mnt/datastore/resultdata/* $output_dir");

--- a/scripts/run_workflow.pl
+++ b/scripts/run_workflow.pl
@@ -11,7 +11,7 @@ use Getopt::Long;
 # creates an INI file, and, finally, executes the workflow.
 
 my @files;
-my ($run_id, $normal_bam, $tumor_bam, $bedpe, $reference);
+my ($run_id, $normal_bam, $tumor_bam, $bedpe, $reference, $output_dir);
 
 # workflow version
 my $wfversion = "2.0.0";
@@ -22,6 +22,7 @@ GetOptions (
   "tumor-bam=s" => \$tumor_bam,
   "delly-bedpe=s" => \$bedpe,
   "reference-gz=s" => \$reference,
+  "output-dir=s" => \$output_dir
 )
 # TODO: need to add all the new params, then symlink the ref files to the right place
  or die("Error in command line arguments\n");
@@ -33,6 +34,8 @@ system("sudo chmod a+rwx /tmp");
 my $pwd = `pwd`;
 print "Present working directory is: $pwd\n";
 
+$ENV{'HOME'} = $output_dir
+
 #check assumptions
 run("whoami");
 run("env");
@@ -42,9 +45,9 @@ run("mkdir -p /data/datastore/normal");
 run("mkdir -p /data/datastore/tumor/");
 run("mkdir -p /data/datastore/delly/");
 run("ln -sf $normal_bam /data/datastore/normal/normal.bam");
-run("ln -sf ${normal_bam}.bai /data/datastore/normal/normal.bam.bai");
+run("ln -sf $normal_bam.bai /data/datastore/normal/normal.bam.bai");
 run("ln -sf $tumor_bam /data/datastore/tumor/tumor.bam");
-run("ln -sf ${tumor_bam}.bai /data/datastore/tumor/tumor.bam.bai");
+run("ln -sf $tumor_bam.bai /data/datastore/tumor/tumor.bam.bai");
 run("ln -sf $bedpe /data/datastore/delly/delly.bedpe.txt");
 run("mkdir -p /mnt/datastore/workflow_data/");
 run("mkdir -p \$TMPDIR/reference");
@@ -78,9 +81,8 @@ close OUT;
 my $error = system("/bin/bash -c '/roddy/bin/runwrapper.sh'");
 
 # MOVE THESE TO THE RIGHT PLACE FOR PROVISION OUT
-my $outputDir = "/var/spool/cwl";
-system("mv /mnt/datastore/resultdata/* $outputDir");
-my $resultData = `ls $outputDir`;
+system("mv /mnt/datastore/resultdata/* $output_dir");
+my $resultData = `ls $output_dir`;
 print "Result directory listing is: $resultData\n";
 
 

--- a/scripts/run_workflow.pl
+++ b/scripts/run_workflow.pl
@@ -79,7 +79,7 @@ close OUT;
 my $error = system("gosu roddy /bin/bash -c '/roddy/bin/runwrapper.sh'");
 
 # MOVE THESE TO THE RIGHT PLACE FOR PROVISION OUT
-system("mv /mnt/datastore/resultdata/* $output_dir");
+system("sudo mv /mnt/datastore/resultdata/* $output_dir");
 my $resultData = `ls $output_dir`;
 print "Result directory listing is: $resultData\n";
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -23,8 +23,9 @@ gosu root ansible-playbook /root/docker-start.yml -c local
 # of cwltool set $PWD same as $HOME
 OUTPUT_DIR=$HOME
 
+# allow cwltool to pick up the results created by seqware
+gosu root chmod -R a+wrx $OUTPUT_DIR
+
 cd $OUTPUT_DIR
 gosu roddy /bin/bash -c "$* --output-dir $OUTPUT_DIR"
 
-# allow cwltool to pick up the results created by seqware
-gosu root chmod -R a+wrx $OUTPUT_DIR

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -7,13 +7,24 @@ set -x
 HOSTNAME=`hostname`
 gosu root chmod a+wrx /etc
 gosu root chmod a+wrx /tmp
-gosu root chmod a+wrx /var/spool/cwl
+
 export TMPDIR=/tmp
-export HOME=/var/spool/cwl
+env
+
 gosu root sed -i 's/placeholder/'$HOSTNAME'/g' /etc/ansible/hosts
 cat /etc/ansible/hosts
 gosu root chmod -R a+wrx /root
 gosu root ansible-playbook /root/docker-start.yml -c local
-gosu roddy /bin/bash -c "$*"
-#allow cwltool to pick up the results created by seqware
-gosu root chmod -R a+wrx  /var/spool/cwl
+
+# newer version of cwltool no longer mounts hardcoded '/var/spool/cwl'
+# as $HOME (used for output in the container). Need to pass current
+# user's $HOME as output-dir. The other choice is $PWD, which is set
+# using '--workdir' in 'docker run' command by cwltool. Currently version
+# of cwltool set $PWD same as $HOME
+OUTPUT_DIR=$HOME
+
+cd $OUTPUT_DIR
+gosu roddy /bin/bash -c "$* --output-dir $OUTPUT_DIR"
+
+# allow cwltool to pick up the results created by seqware
+gosu root chmod -R a+wrx $OUTPUT_DIR


### PR DESCRIPTION
This now has been tested both on Collab and Seven Bridges CGC platforms.

The PR also includes fix to remove dependent on hardcoded `/var/spool/cwl` output directory.