### PR TITLE
Standard output names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # install perl modules
-RUN cpanm Math::CDF
+RUN cpanm --no-lwp Math::CDF Capture::Tiny
 
 # install python modules
 RUN pip install --index-url https://pypi.python.org/simple/ --upgrade pip && hash -r

--- a/Dockstore.cwl
+++ b/Dockstore.cwl
@@ -20,33 +20,33 @@ cwlVersion: v1.0
 
 inputs:
   run-id:
-    type: string
+    type: string?
     inputBinding:
-      position: 1
+      position: 5
       prefix: --run-id
   tumor-bam:
     type: File
     inputBinding:
-      position: 3
+      position: 2
       prefix: --tumor-bam
     secondaryFiles:
     - .bai
   normal-bam:
     type: File
     inputBinding:
-      position: 2
+      position: 1
       prefix: --normal-bam
     secondaryFiles:
     - .bai
   reference-gz:
     type: File
     inputBinding:
-      position: 4
+      position: 3
       prefix: --reference-gz
   delly-bedpe:
     type: File
     inputBinding:
-      position: 5
+      position: 4
       prefix: --delly-bedpe
 
 outputs:

--- a/Dockstore.cwl
+++ b/Dockstore.cwl
@@ -19,23 +19,18 @@ requirements:
 cwlVersion: v1.0
 
 inputs:
-  run-id:
-    type: string?
-    inputBinding:
-      position: 5
-      prefix: --run-id
-  tumor-bam:
-    type: File
-    inputBinding:
-      position: 2
-      prefix: --tumor-bam
-    secondaryFiles:
-    - .bai
   normal-bam:
     type: File
     inputBinding:
       position: 1
       prefix: --normal-bam
+    secondaryFiles:
+    - .bai
+  tumor-bam:
+    type: File
+    inputBinding:
+      position: 2
+      prefix: --tumor-bam
     secondaryFiles:
     - .bai
   reference-gz:
@@ -48,6 +43,12 @@ inputs:
     inputBinding:
       position: 4
       prefix: --delly-bedpe
+  run-id:
+    type: string?
+    inputBinding:
+      position: 5
+      prefix: --run-id
+
 
 outputs:
   somatic_cnv_tar_gz:

--- a/Dockstore.cwl
+++ b/Dockstore.cwl
@@ -14,7 +14,7 @@ dct:contributor:
 
 requirements:
 - class: DockerRequirement
-  dockerPull: quay.io/pancancer/pcawg-dkfz-workflow:2.1.0
+  dockerPull: quay.io/pancancer/pcawg-dkfz-workflow:standard-output-names
 
 cwlVersion: v1.0
 

--- a/scripts/run_workflow.pl
+++ b/scripts/run_workflow.pl
@@ -121,7 +121,9 @@ sub get_aliquot_id_from_bam {
   for ( split "\n", $stdout ) {
     chomp $_;
     if ( $_ =~ m/\tSM:([^\t]+)/ ) {
-      $names{$1} = 1;
+      $sm = $1
+      $sm =~ s/[^\w^\-^_]/_/g;  # convert non-filename-friendly characters to underscores
+      $names{$sm} = 1;
     }
     else {
       die "Found RG line with no SM field: $_\n\tfrom: $bam\n";

--- a/scripts/run_workflow.pl
+++ b/scripts/run_workflow.pl
@@ -39,9 +39,8 @@ if ($run_id eq "")
 if ($run_id =~ /^[a-zA-Z0-9_-]+$/) {
     print "run-id is: $run_id\n";
 } else {
-    die "Found run-id contains invalid character: $run_id\n";
+    die "Found run-id containing invalid character: $run_id\n";
 }
-
 
 # PARSE OPTIONS
 system("sudo chmod a+rwx /tmp");

--- a/scripts/run_workflow.pl
+++ b/scripts/run_workflow.pl
@@ -34,8 +34,14 @@ GetOptions (
 if ($run_id eq "")
 {
   $run_id = get_aliquot_id_from_bam($tumor_bam);
-  print "run-id is: $run_id\n";
 }
+
+if ($run_id =~ /^[a-zA-Z0-9_-]+$/) {
+    print "run-id is: $run_id\n";
+} else {
+    die "Found run-id contains invalid character: $run_id\n";
+}
+
 
 # PARSE OPTIONS
 system("sudo chmod a+rwx /tmp");

--- a/scripts/run_workflow.pl
+++ b/scripts/run_workflow.pl
@@ -121,7 +121,7 @@ sub get_aliquot_id_from_bam {
   for ( split "\n", $stdout ) {
     chomp $_;
     if ( $_ =~ m/\tSM:([^\t]+)/ ) {
-      $sm = $1;
+      my $sm = $1;
       $sm =~ s/[^\w^\-^_]/_/g;  # convert non-filename-friendly characters to underscores
       $names{$sm} = 1;
     }

--- a/scripts/run_workflow.pl
+++ b/scripts/run_workflow.pl
@@ -33,7 +33,7 @@ GetOptions (
 
 if ($run_id eq "")
 {
-  $run_id = get_aliquot_id_from_bam($tumor_bam);
+  $run_id = get_run_id_from_sm_in_bam($tumor_bam);
 }
 
 if ($run_id =~ /^[a-zA-Z0-9_-]+$/) {
@@ -109,7 +109,7 @@ sub run {
   if ($error) { exit($error); }
 }
 
-sub get_aliquot_id_from_bam {
+sub get_run_id_from_sm_in_bam {
   my $bam = shift;
   die "BAM file does not exist: $bam" unless ( -e $bam );
 

--- a/scripts/run_workflow.pl
+++ b/scripts/run_workflow.pl
@@ -33,7 +33,7 @@ GetOptions (
 
 if ($run_id eq "")
 {
-  $run_id = get_aliquot_id_from_bam($tumor_bam)
+  $run_id = get_aliquot_id_from_bam($tumor_bam);
   print "run-id is: $run_id\n";
 }
 

--- a/scripts/run_workflow.pl
+++ b/scripts/run_workflow.pl
@@ -2,6 +2,7 @@
 
 use strict;
 use Getopt::Long;
+use Time::Piece;
 
 ########
 # ABOUT
@@ -12,6 +13,7 @@ use Getopt::Long;
 
 my @files;
 my ($run_id, $normal_bam, $tumor_bam, $bedpe, $reference, $output_dir);
+my $date = localtime->strftime('%Y%m%d');
 
 # workflow version
 my $wfversion = "2.0.0";
@@ -68,7 +70,7 @@ aliquotIDs=( $run_id )
 runACEeq=true
 runSNVCalling=true
 runIndelCalling=true
-date=20160520
+date=$date
 END
 
 open OUT, ">/mnt/datastore/workflow_data/workflow.ini" or die;

--- a/scripts/run_workflow.pl
+++ b/scripts/run_workflow.pl
@@ -121,7 +121,7 @@ sub get_aliquot_id_from_bam {
   for ( split "\n", $stdout ) {
     chomp $_;
     if ( $_ =~ m/\tSM:([^\t]+)/ ) {
-      $sm = $1
+      $sm = $1;
       $sm =~ s/[^\w^\-^_]/_/g;  # convert non-filename-friendly characters to underscores
       $names{$sm} = 1;
     }

--- a/scripts/run_workflow.pl
+++ b/scripts/run_workflow.pl
@@ -3,7 +3,7 @@
 use strict;
 use Getopt::Long;
 use Time::Piece;
-use Bio::DB::Sam;
+use Capture::Tiny qw(capture);
 
 ########
 # ABOUT
@@ -13,16 +13,16 @@ use Bio::DB::Sam;
 # creates an INI file, and, finally, executes the workflow.
 
 my @files;
-my ($normal_bam, $tumor_bam, $bedpe, $reference, $output_dir);
+my ($normal_bam, $tumor_bam, $bedpe, $reference, $output_dir, $run_id);
 my $date = localtime->strftime('%Y%m%d');
-my $run_id = sample_name($tumor_bam);
+
 
 # workflow version
 my $wfversion = "2.0.0";
 
 GetOptions (
   "output-dir=s" => \$output_dir,
-  "run-id=s"   => \$run_id,
+  "run-id:s"   => \$run_id,
   "normal-bam=s" => \$normal_bam,
   "tumor-bam=s" => \$tumor_bam,
   "delly-bedpe=s" => \$bedpe,
@@ -30,6 +30,12 @@ GetOptions (
 )
 # TODO: need to add all the new params, then symlink the ref files to the right place
  or die("Error in command line arguments\n");
+
+if ($run_id eq "")
+{
+  $run_id = get_aliquot_id_from_bam($tumor_bam)
+  print "run-id is: $run_id\n";
+}
 
 # PARSE OPTIONS
 system("sudo chmod a+rwx /tmp");
@@ -98,16 +104,30 @@ sub run {
   if ($error) { exit($error); }
 }
 
-sub sample_name {
-  my $control_bam = shift;
-  my @lines = split /\n/, Bio::DB::Sam->new(-bam => $control_bam)->header->text;
-  my $sample;
-  for(@lines) {
-    if($_ =~ m/^\@RG.*\tSM:([^\t]+)/) {
-      $sample = $1;
-      last;
+sub get_aliquot_id_from_bam {
+  my $bam = shift;
+  die "BAM file does not exist: $bam" unless ( -e $bam );
+
+  my $command = sprintf q{samtools view -H %s | grep '^@RG'}, $bam;
+  my ($stdout, $stderr, $exit) = capture { system($command); };
+  die "STDOUT: $stdout\n\nSTDERR: $stderr\n" if ( $exit != 0 );
+
+  my %names;
+  for ( split "\n", $stdout ) {
+    chomp $_;
+    if ( $_ =~ m/\tSM:([^\t]+)/ ) {
+      $names{$1} = 1;
+    }
+    else {
+      die "Found RG line with no SM field: $_\n\tfrom: $bam\n";
     }
   }
-  die "Failed to determine sample from BAM header\n" unless(defined $sample);
-  return $sample;
+
+  my @keys = keys %names;
+  die "Multiple different SM entries: ."
+    . join( q{,}, @keys )
+    . "\n\tfrom: $bam\n"
+    if ( scalar @keys > 1 );
+  die "No SM entry found in: $bam\n" if ( scalar @keys == 0 );
+  return $keys[0];
 }

--- a/scripts/run_workflow.pl
+++ b/scripts/run_workflow.pl
@@ -36,8 +36,11 @@ if ($run_id eq "")
   $run_id = get_aliquot_id_from_bam($tumor_bam);
 }
 
-$run_id =~ s/[^\w^\-^_]/_/g;  # convert non-filename-friendly characters to underscores
-print "run-id is: $run_id\n";
+if ($run_id =~ /^[a-zA-Z0-9_-]+$/) {
+    print "run-id is: $run_id\n";
+} else {
+    die "Found run-id containing invalid character: $run_id\n";
+}
 
 # PARSE OPTIONS
 system("sudo chmod a+rwx /tmp");
@@ -118,7 +121,9 @@ sub get_aliquot_id_from_bam {
   for ( split "\n", $stdout ) {
     chomp $_;
     if ( $_ =~ m/\tSM:([^\t]+)/ ) {
-      $names{$1} = 1;
+      my $sm = $1;
+      $sm =~ s/[^\w^\-^_]/_/g;  # convert non-filename-friendly characters to underscores
+      $names{$sm} = 1;
     }
     else {
       die "Found RG line with no SM field: $_\n\tfrom: $bam\n";

--- a/scripts/run_workflow.pl
+++ b/scripts/run_workflow.pl
@@ -36,11 +36,8 @@ if ($run_id eq "")
   $run_id = get_aliquot_id_from_bam($tumor_bam);
 }
 
-if ($run_id =~ /^[a-zA-Z0-9_-]+$/) {
-    print "run-id is: $run_id\n";
-} else {
-    die "Found run-id containing invalid character: $run_id\n";
-}
+$run_id =~ s/[^\w^\-^_]/_/g;  # convert non-filename-friendly characters to underscores
+print "run-id is: $run_id\n";
 
 # PARSE OPTIONS
 system("sudo chmod a+rwx /tmp");
@@ -121,9 +118,7 @@ sub get_aliquot_id_from_bam {
   for ( split "\n", $stdout ) {
     chomp $_;
     if ( $_ =~ m/\tSM:([^\t]+)/ ) {
-      my $sm = $1;
-      $sm =~ s/[^\w^\-^_]/_/g;  # convert non-filename-friendly characters to underscores
-      $names{$sm} = 1;
+      $names{$1} = 1;
     }
     else {
       die "Found RG line with no SM field: $_\n\tfrom: $bam\n";


### PR DESCRIPTION
- autoset run dateString in the ini file
- expose run-id to be optional at cwl level and set the default value of run-id to be SM in RG of BAM header
- standard the output files prefixed with the PCAWG convention: <run-id>.<workflowName>.<dateString>
- modify Dockerfile to install more perl modules